### PR TITLE
Feature/a11y updates

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,7 +8,7 @@ import { SITE_TITLE } from "../consts";
 	<nav>
 		<h2>{Astro.url.pathname === "/" ? "" : <a href="/">{SITE_TITLE}</a>}</h2>
 		<div class="internal-links">
-			<HeaderLink href="/about" title="about">
+			<HeaderLink href="/about" alt="about">
 				<Icon.Person size={20} fill="currentColor" title="about" />
 			</HeaderLink>
 			<HeaderLink href="/rss.xml" alt="rss">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,14 +8,14 @@ import { SITE_TITLE } from "../consts";
 	<nav>
 		<h2>{Astro.url.pathname === "/" ? "" : <a href="/">{SITE_TITLE}</a>}</h2>
 		<div class="internal-links">
-			<HeaderLink href="/about" alt="about">
-				<Icon.Person size={20} fill="currentColor" alt="about" />
+			<HeaderLink href="/about" title="about">
+				<Icon.Person size={20} fill="currentColor" title="about" />
 			</HeaderLink>
 			<HeaderLink href="/rss.xml" alt="rss">
-				<Icon.Globe size={20} fill="currentColor" alt="rss" />
+				<Icon.Globe size={20} fill="currentColor" title="rss" />
 			</HeaderLink>
 			<HeaderLink href="/archive" alt="archive">
-				<Icon.Archive size={20} fill="currentColor" alt="archive" />
+				<Icon.Archive size={20} fill="currentColor" title="archive" />
 			</HeaderLink>
 		</div>
 	</nav>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,7 +11,7 @@
   --gray-dark: 216, 222, 233;
   --gray-gradient: rgba(var(--gray-light), 50%), #fff;
   --blue-light: 129, 161, 193;
-  --blue: 94, 129, 172;
+  --blue: 76, 111, 154;
 
   --box-shadow: 0 2px 6px rgba(var(--gray), 25%),
     0 8px 24px rgba(var(--gray), 33%), 0 16px 32px rgba(var(--gray), 33%);


### PR DESCRIPTION
:wave:  Hi Jake,

This PR contains a11y tweaks;

- [ ] 851bb5734b55cd41c88d9584467601ec8d01e130 - the sites current contrast ratio fails AA. Tweaked it so it just squeaks by.
- [ ] 851bb5734b55cd41c88d9584467601ec8d01e130 etc. -  Astro's Icon component "doesn't support" the use of `alt` attributes on SVG's. This is due to the fact `alt` in this case is intended for `<img>` tags. So I switched it to the supported `title` attribute which *is* supported by the Astro Icon component. as outlined at this documentation url: https://github.com/astro-community/icons?tab=readme-ov-file#prop-types . This provides the browser with the necessary "alt text" as expected on hover. See Image 1

1 ![new alt text](https://github.com/jakehamilton/nixpkgs.news/assets/500963/f6876063-544a-4d08-ac1f-3827c838a046)
